### PR TITLE
Fix get host function may return empty string without warning

### DIFF
--- a/proxy/net.go
+++ b/proxy/net.go
@@ -34,16 +34,17 @@ func GetIP(r *http.Request) string {
 }
 
 // GetHost get the hostname, looks like IP:Port
-func GetHost(url *url.URL) string {
+func GetHost(url *url.URL) (string, error) {
 	if _, _, err := net.SplitHostPort(url.Host); err == nil {
-		return url.Host
+		return url.Host, nil
 	}
 	if url.Scheme == "http" {
-		return fmt.Sprintf("%s:%s", url.Host, "80")
+		return fmt.Sprintf("%s:%s", url.Host, "80"), nil
 	} else if url.Scheme == "https" {
-		return fmt.Sprintf("%s:%s", url.Host, "443")
+		return fmt.Sprintf("%s:%s", url.Host, "443"), nil
+	} else {
+		return "", fmt.Errorf("bad url %s, scheme is %s, neither http nor https", url, url.Scheme)
 	}
-	return url.Host
 }
 
 // IsBackendAlive Attempt to establish a tcp connection to determine whether the site is alive

--- a/proxy/net.go
+++ b/proxy/net.go
@@ -42,9 +42,8 @@ func GetHost(url *url.URL) (string, error) {
 		return fmt.Sprintf("%s:%s", url.Host, "80"), nil
 	} else if url.Scheme == "https" {
 		return fmt.Sprintf("%s:%s", url.Host, "443"), nil
-	} else {
-		return "", fmt.Errorf("bad url %s, scheme is %s, neither http nor https", url, url.Scheme)
 	}
+	return "", fmt.Errorf("bad url %s, scheme is %s, neither http nor https", url, url.Scheme)
 }
 
 // IsBackendAlive Attempt to establish a tcp connection to determine whether the site is alive

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -59,6 +59,7 @@ func NewHTTPProxy(targetHosts []string, algorithm string) (
 		if err != nil {
 			return nil, fmt.Errorf("get host error: %s", err)
 		}
+		host = ""
 		alive[host] = true // initial mark alive
 		hostMap[host] = proxy
 		hosts = append(hosts, host)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -55,7 +55,10 @@ func NewHTTPProxy(targetHosts []string, algorithm string) (
 			req.Header.Set(XRealIP, GetIP(req))
 		}
 
-		host := GetHost(url)
+		host, err := GetHost(url)
+		if err != nil {
+			return nil, fmt.Errorf("get host error: %s", err)
+		}
 		alive[host] = true // initial mark alive
 		hostMap[host] = proxy
 		hosts = append(hosts, host)


### PR DESCRIPTION
User may add wrong format of proxy_pass in `config.yaml`, such as `localhost:8000` (which should be `http://loaclhost:8000`), net.GetHost() will return an empty string without error, which causes weird behavior at runtime:

Original:
```go
host := GetHost(url)
alive[host] = true // initial mark alive
hostMap[host] = proxy
```
Now add error handling:
```go
host, err := GetHost(url)
if err != nil {
	return nil, fmt.Errorf("get host error: %s", err)
}
alive[host] = true // initial mark alive
hostMap[host] = proxy
hosts = append(hosts, host)
```